### PR TITLE
one more request

### DIFF
--- a/src/Providers/LaminasFormServiceProvider.php
+++ b/src/Providers/LaminasFormServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Revolution\LaminasForm\Providers;
 
+use Illuminate\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
 use Laminas\Form\ConfigProvider;
 use Laminas\ServiceManager\ServiceManager;
@@ -47,7 +48,7 @@ class LaminasFormServiceProvider extends ServiceProvider
 
         $this->app->singleton(
             RendererInterface::class,
-            function ($app) {
+            static function (Application $app) {
                 $renderer = new PhpRenderer();
                 $configProvider = new ConfigProvider();
 
@@ -56,7 +57,10 @@ class LaminasFormServiceProvider extends ServiceProvider
                     $app['config']['laminas-form']
                 );
 
-                $pluginManager = new HelperPluginManager(new ServiceManager(), $config);
+                $pluginManager = new HelperPluginManager(
+                    new ServiceManager($app['config']['serviceManager'] ?? []),
+                    $config
+                );
 
                 $renderer->setHelperPluginManager($pluginManager);
 

--- a/src/Providers/LaminasFormServiceProvider.php
+++ b/src/Providers/LaminasFormServiceProvider.php
@@ -3,13 +3,11 @@
 namespace Revolution\LaminasForm\Providers;
 
 use Illuminate\Support\ServiceProvider;
-
-use Laminas\View\Renderer\RendererInterface;
-use Laminas\View\Renderer\PhpRenderer;
-use Laminas\View\HelperPluginManager;
 use Laminas\Form\ConfigProvider;
 use Laminas\ServiceManager\ServiceManager;
-
+use Laminas\View\HelperPluginManager;
+use Laminas\View\Renderer\PhpRenderer;
+use Laminas\View\Renderer\RendererInterface;
 use Revolution\LaminasForm\Commands;
 
 class LaminasFormServiceProvider extends ServiceProvider
@@ -29,7 +27,7 @@ class LaminasFormServiceProvider extends ServiceProvider
 
         $this->publishes(
             [
-                __DIR__.'/../config/laminas-form.php' => config_path('laminas-form.php'),
+                __DIR__ . '/../config/laminas-form.php' => config_path('laminas-form.php'),
             ],
             'laminas-form-config'
         );
@@ -43,7 +41,7 @@ class LaminasFormServiceProvider extends ServiceProvider
     public function register()
     {
         $this->mergeConfigFrom(
-            __DIR__.'/../config/laminas-form.php',
+            __DIR__ . '/../config/laminas-form.php',
             'laminas-form'
         );
 
@@ -53,7 +51,7 @@ class LaminasFormServiceProvider extends ServiceProvider
                 $renderer = new PhpRenderer();
                 $configProvider = new ConfigProvider();
 
-                $config = array_merge_recursive(
+                $config = array_replace_recursive(
                     $configProvider->getViewHelperConfig(),
                     $app['config']['laminas-form']
                 );


### PR DESCRIPTION
Configuration shouldnt be merged with array_merge_recursive,
because then it isnt possible to override di-container definitions. Using array_replace_recursive works fine, also when new configurable parameters will be added on configuration.

Also it wasnt possible to override the ServiceManager configuration, for setting Translator or else, now its also possible to control through the Configuration the loading of a Translator-class or else. 